### PR TITLE
fix table not resizing when window shrinks

### DIFF
--- a/src/plugin/iframe_root/modules/components/table.js
+++ b/src/plugin/iframe_root/modules/components/table.js
@@ -41,7 +41,8 @@ define([
             css: {
                 flex: '1 1 0px',
                 display: 'flex',
-                flexDirection: 'column'
+                flexDirection: 'column',
+                overflowY: 'hidden'
             }
         },
         itemRows: {


### PR DESCRIPTION
- just needed overflowY set to hidden for the tableBody, which is what is measured for paging.